### PR TITLE
Implement Hawk authentication for accept endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 - `npm run lint` - check JS syntax & formatting
 - `npm run test` - run JS tests
 - `npm run watch` - start a file watcher that runs tests & lint
+- `npm run prettier` - clean up JS formatting
+- `npm run deploy:dev -- --stage lmorchard` - deploy a stack with stage `lmorchard` configured for development (e.g. with `ENABLE_DEV_AUTH=1`)
+- `npm run logs -- --stage lmorchard -f accept -t` - watch logs for the function `accept`
+- `npm run deploy -- --stage production` - deploy a stack with stage `production` configured for production
+- `npm run client -- [--id <id> --key <key>] <url>` - make an authenticated request to `<url>` using Hawk credentials, defaults to dev credentials devuser / devkey enabled with `ENABLE_DEV_AUTH` env var on deploy
 
 ### Quickstart Notes for Stackless on AWS
 
@@ -28,11 +33,13 @@ If you don't already have an AWS key ID and secret, [follow the guide to acquire
 
 Choose a unique stage name to use for development - e.g. mine is `lmorchard`. This is used in naming all the pieces of the stack you deploy, in order to distinguish them from any other stack.
 
-Try deploying the service to AWS: `npm run deploy -- --stage <stage name>`
+Try deploying the service to AWS:
+
+`npm run deploy:dev -- --stage <stage name>`
 
 You should see output like the following:
 ```
-$ npm run deploy -- --stage lmorchard
+$ npm run deploy:dev -- --stage lmorchard
 Serverless: Packaging service...
 Serverless: Excluding development dependencies...
 Serverless: Creating Stack...
@@ -67,13 +74,3 @@ If everything was successful, you should now have a running stack with an HTTPS 
 To remove this stack from AWS and delete everything, run `npm run remove -- --stage <stage name>`
 
 The [Serverless docs on workflow are useful](https://serverless.com/framework/docs/providers/aws/guide/workflow/).
-
-These are also a few useful example commands:
-```
-# Tail logs from lambda functions
-npm run logs -- --stage lmorchard -f accept -t
-
-# Deploy an individual function on file changes (double-double-dashes because
-shells are weird)
-npm run watch:deploy -- -- --stage lmorchard -f accept
-```

--- a/bin/client.js
+++ b/bin/client.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+const { URL } = require("url");
+const Hawk = require("hawk");
+const request = require("request-promise-native");
+const program = require("commander");
+const { devCredentials } = require("../lib/constants");
+const packageData = require("../package.json");
+
+async function main() {
+  program
+    .version(packageData.version)
+    .usage("[options] <url>")
+    .option("-i, --id <id>", "User id")
+    .option("-k, --key <key>", "User key")
+    .parse(process.argv);
+
+  const [ url ] = program.args;
+  if (!url) {
+    console.error("URL required");
+    program.outputHelp();
+    return "";
+  }
+
+  const { header: Authorization } = Hawk.client.header(
+    url,
+    "POST",
+    {
+      credentials: {
+        id: program.id || "devuser",
+        key: program.key || "devkey",
+        algorithm: "sha256"
+      }
+    }
+  );
+
+  return await request({
+    method: "POST",
+    url,
+    headers: { Authorization }
+  });
+}
+
+main()
+  .then(console.log)
+  .catch(err => console.error("ERROR", err.message));

--- a/functions/accept.js
+++ b/functions/accept.js
@@ -1,28 +1,52 @@
 "use strict";
 
+const Hawk = require("hawk");
 const AWS = require("aws-sdk");
 const S3 = new AWS.S3({ apiVersion: "2006-03-01" });
 const SQS = new AWS.SQS({ apiVersion: "2012-11-05" });
+const documentClient = new AWS.DynamoDB.DocumentClient();
+const { DEV_CREDENTIALS, DEFAULT_HAWK_ALGORITHM } = require("../lib/constants");
 
-const { QUEUE_NAME, CONTENT_BUCKET } = process.env;
-module.exports.handler = async function(
-  { requestContext: { requestId } },
-  context
-) {
-  console.time("accept");
-  const responseCode = 200;
-  const responseBody = { requestId };
+module.exports.post = async function(event, context) {
+  const { NODE_ENV, QUEUE_NAME, CONTENT_BUCKET } = process.env;
+  const {
+    headers,
+    // body,
+    queryStringParameters,
+    requestContext: { path, requestId }
+  } = event;
+  const {
+    Host: host,
+    Authorization: authorization,
+    "X-Forwarded-Port": port = 80
+  } = headers;
 
-  console.time("acceptS3");
+  const responseBody = { requestId, env: NODE_ENV };
+
+  try {
+    responseBody.hawk = await authenticate({
+      method: "POST",
+      path,
+      queryStringParameters,
+      host,
+      port,
+      authorization
+    });
+  } catch (err) {
+    return response(
+      401,
+      { error: err.message },
+      { "WWW-Authenticate": "Hawk" }
+    );
+  }
+
   const result = await S3.putObject({
     Bucket: CONTENT_BUCKET,
     Key: requestId,
     Body: "THIS WILL BE AN IMAGE SOMEDAY"
   }).promise();
   responseBody.s3Result = result;
-  console.timeEnd("acceptS3");
 
-  console.time("acceptSQS");
   const { QueueUrl } = await SQS.getQueueUrl({
     QueueName: QUEUE_NAME
   }).promise();
@@ -34,11 +58,70 @@ module.exports.handler = async function(
     QueueUrl
   }).promise();
   responseBody.sqsResult = "SUCCESS " + MessageId;
-  console.timeEnd("acceptSQS");
 
-  console.timeEnd("accept");
-  return {
-    statusCode: responseCode,
-    body: JSON.stringify(responseBody)
-  };
+  return response(200, responseBody);
 };
+
+function response(statusCode, body, headers = {}) {
+  return {
+    statusCode,
+    headers: Object.assign({ "Content-Type": "application/json" }, headers),
+    body: JSON.stringify(body)
+  };
+}
+
+async function authenticate({
+  method = "POST",
+  path,
+  queryStringParameters,
+  host,
+  port,
+  authorization
+}) {
+  const request = {
+    method,
+    url: path,
+    host,
+    port,
+    authorization
+  };
+  return Hawk.server.authenticate(request, lookupCredentials, {});
+}
+
+// In-memory credentials lookup cache, only lasts until next deployment or
+// container is recycled. Saves a DynamoDB hit and ~900ms for most requests
+const credentialsCache = {};
+
+async function lookupCredentials(id) {
+  const {
+    ENABLE_DEV_AUTH,
+    DISABLE_AUTH_CACHE,
+    CREDENTIALS_TABLE: TableName
+  } = process.env;
+
+  let out;
+
+  if (ENABLE_DEV_AUTH === "1" && id in DEV_CREDENTIALS) {
+    out = DEV_CREDENTIALS[id];
+  } else if (DISABLE_AUTH_CACHE !== "1" && id in credentialsCache) {
+    out = credentialsCache[id];
+  } else {
+    const result = await documentClient
+      .get({
+        TableName,
+        Key: { id },
+        AttributesToGet: ["key", "algorithm"]
+      })
+      .promise();
+    if (!result.Item) {
+      out = null;
+    } else {
+      const {
+        Item: { key, algorithm = DEFAULT_HAWK_ALGORITHM }
+      } = result;
+      out = credentialsCache[id] = { id, key, algorithm };
+    }
+  }
+
+  return out;
+}

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,8 @@
+exports.DEFAULT_HAWK_ALGORITHM = "sha256";
+
+exports.DEV_CREDENTIALS = {
+  devuser: {
+    key: "devkey",
+    algorithm: exports.DEFAULT_HAWK_ALGORITHM
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -597,11 +597,20 @@
       "dev": true
     },
     "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
+      "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "5.0.3"
+      }
+    },
+    "bounce": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bounce/-/bounce-1.2.0.tgz",
+      "integrity": "sha512-8syCGe8B2/WC53118/F/tFy5aW00j+eaGPXmAUP7iBhxc+EBZZxS1vKelWyBCH6IqojgS2t1gF0glH30qAJKEw==",
+      "requires": {
+        "boom": "7.2.0",
+        "hoek": "5.0.3"
       }
     },
     "boxen": {
@@ -1073,13 +1082,10 @@
       }
     },
     "commander": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-      "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": "1.0.1"
-      }
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -1201,6 +1207,16 @@
         "capture-stack-trace": "1.0.0"
       }
     },
+    "cross-env": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.4.tgz",
+      "integrity": "sha512-Mx8mw6JWhfpYoEk7PGvHxJMLQwQHORAs8+2bX+C1lGQ4h3GkDb1zbzC2Nw85YH9ZQMlO0BHZxMacgrfPmMFxbg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "is-windows": "1.0.2"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -1213,21 +1229,11 @@
       }
     },
     "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.1.tgz",
+      "integrity": "sha512-YuQUPbcOmaZsdvxJZ25DCA1W+lLIRoPJKBDKin+St1RCYEERSfoe1d25B1MvWNHN3e8SpFSVsqYvEUjp8J9H2w==",
       "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        }
+        "boom": "7.2.0"
       }
     },
     "crypto-random-string": {
@@ -3336,14 +3342,14 @@
       }
     },
     "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-7.0.7.tgz",
+      "integrity": "sha512-Vr0JSJCDO3wajpu/YDTArTPPloLFhkzj7s45HYDP+tJuleTYKcTplbVT4+xx6YHzOxD1GBUisxCSz9u58eOOSA==",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "7.2.0",
+        "cryptiles": "4.1.1",
+        "hoek": "5.0.3",
+        "sntp": "3.0.1"
       }
     },
     "he": {
@@ -3353,9 +3359,9 @@
       "dev": true
     },
     "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+      "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
     },
     "hosted-git-info": {
       "version": "2.6.0",
@@ -4585,14 +4591,6 @@
         "path-loader": "1.0.4",
         "slash": "1.0.0",
         "uri-js": "3.0.2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-          "dev": true
-        }
       }
     },
     "json-schema": {
@@ -4768,12 +4766,6 @@
             "escape-string-regexp": "1.0.5",
             "supports-color": "5.4.0"
           }
-        },
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-          "dev": true
         },
         "debug": {
           "version": "3.1.0",
@@ -5519,14 +5511,6 @@
         "commander": "2.15.1",
         "npm-path": "2.0.4",
         "which": "1.3.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-          "dev": true
-        }
       }
     },
     "npmlog": {
@@ -6587,6 +6571,58 @@
         "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
         "uuid": "3.2.1"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "requires": {
+                "hoek": "4.2.1"
+              }
+            }
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.1",
+            "sntp": "2.1.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        }
       }
     },
     "request-promise-core": {
@@ -6770,6 +6806,17 @@
       "dev": true,
       "requires": {
         "commander": "2.8.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        }
       }
     },
     "semver": {
@@ -7166,11 +7213,14 @@
       }
     },
     "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-3.0.1.tgz",
+      "integrity": "sha512-k2SIWd9c1dBRDLalpr2Ioc64bPxTpmUwSsQi+w7CLdizUIvGrbUZloEHw5I6VeqCKNWjL9p7n+LdtD5XQXJMbw==",
       "requires": {
-        "hoek": "4.2.1"
+        "boom": "7.2.0",
+        "bounce": "1.2.0",
+        "hoek": "5.0.3",
+        "teamwork": "3.0.1"
       }
     },
     "source-map": {
@@ -7616,6 +7666,11 @@
         "to-buffer": "1.1.1",
         "xtend": "4.0.1"
       }
+    },
+    "teamwork": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/teamwork/-/teamwork-3.0.1.tgz",
+      "integrity": "sha512-hEkJIpDOfOYe9NYaLFk00zQbzZeKNCY8T2pRH3I13Y1mJwxaSQ6NEsjY5rCp+11ezCiZpWGoGFTbOuhg4qKevQ=="
     },
     "term-size": {
       "version": "1.2.0",
@@ -8268,6 +8323,12 @@
           "requires": {
             "hoek": "4.2.1"
           }
+        },
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "precommit": "lint-staged && npm run test:js",
     "deploy": "serverless deploy",
+    "deploy:dev": "cross-env-shell NODE_ENV=development ENABLE_DEV_AUTH=1 npm run deploy --",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint functions lib test",
     "prettier": "prettier --write \"{functions,lib,test}/**/*.js\"",
@@ -16,7 +17,8 @@
     "test:js": "mocha --recursive test",
     "watch": "npm-run-all --parallel watch:*",
     "watch:lint": "onchange -v -i \"{functions,lib,test}/**/*.js\" -- npm run lint",
-    "watch:test": "onchange -v -i \"{functions,lib,test}/**/*.js\" -- npm run test"
+    "watch:test": "onchange -v -i \"{functions,lib,test}/**/*.js\" -- npm run test",
+    "client": "node bin/client.js"
   },
   "lint-staged": {
     "*.js": [
@@ -34,6 +36,8 @@
   "devDependencies": {
     "aws-sdk": "2.234.1",
     "chai": "4.1.2",
+    "commander": "2.15.1",
+    "cross-env": "5.1.4",
     "eslint": "4.19.1",
     "eslint-plugin-mozilla": "0.11.0",
     "eslint-plugin-no-unsanitized": "3.0.0",
@@ -50,6 +54,7 @@
     "sinon": "5.0.7"
   },
   "dependencies": {
+    "hawk": "7.0.7",
     "request": "2.85.0",
     "request-promise-native": "1.0.5"
   }

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,9 +9,19 @@ custom:
   prefix: ${self:service}-${self:custom.stage}
   process: ${self:custom.prefix}-processQueueItem
   config: ${self:custom.prefix}-config
-  sns: ${self:custom.prefix}-trigger
+  credentials: ${self:custom.prefix}-credentials
   sqs: ${self:custom.prefix}-messages
   contentBucket: ${self:custom.prefix}-content
+  fnEnv:
+      NODE_ENV: ${env:NODE_ENV,"production"}
+      ENABLE_DEV_AUTH: ${env:ENABLE_DEV_AUTH,"0"}
+      SERVICE_STAGE: ${self:custom.stage}
+      SERVICE_PREFIX: ${self:custom.prefix}
+      CONFIG_TABLE: ${self:custom.config}
+      CREDENTIALS_TABLE: ${self:custom.credentials}
+      QUEUE_NAME: ${self:custom.sqs}
+      CONTENT_BUCKET: ${self:custom.contentBucket}
+      PROCESS_QUEUE_FUNCTION: ${self:custom.process}
   remover:
     buckets:
       - ${self:custom.contentBucket}
@@ -33,6 +43,7 @@ provider:
       - dynamodb:Scan
     Resource:
       - arn:aws:dynamodb:*:*:table/${self:custom.config}
+      - arn:aws:dynamodb:*:*:table/${self:custom.credentials}
   - Effect: Allow
     Action:
       - lambda:InvokeFunction
@@ -92,6 +103,20 @@ resources:
         QueueName: ${self:custom.sqs}-dead-letter-queue
         MessageRetentionPeriod: 1209600
 
+    Credentials:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:custom.credentials}
+        AttributeDefinitions:
+          - AttributeName: id
+            AttributeType: S
+        KeySchema:
+          - AttributeName: id
+            KeyType: HASH
+        ProvisionedThroughput:
+          ReadCapacityUnits: 5
+          WriteCapacityUnits: 5
+
     Config:
       Type: AWS::DynamoDB::Table
       Properties:
@@ -115,34 +140,24 @@ package:
 functions:
 
   accept:
-    handler: functions/accept.handler
+    handler: functions/accept.post
     name: ${self:custom.prefix}-accept
-    environment:
-      CONFIG_TABLE: ${self:custom.config}
-      QUEUE_NAME: ${self:custom.sqs}
-      CONTENT_BUCKET: ${self:custom.contentBucket}
+    environment: ${self:custom.fnEnv}
     events:
       - http:
           path: accept
-          method: get
+          method: post
 
   pollQueue:
     timeout: 60
     handler: functions/pollQueue.handler
     name: ${self:custom.prefix}-pollQueue
-    environment:
-      CONFIG_TABLE: ${self:custom.config}
-      QUEUE_NAME: ${self:custom.sqs}
-      CONTENT_BUCKET: ${self:custom.contentBucket}
-      PROCESS_QUEUE_FUNCTION: ${self:custom.process}
+    environment: ${self:custom.fnEnv}
     events:
       - schedule: rate(1 minute)
-  
+
   processQueueItem:
     timeout: 60
     handler: functions/processQueueItem.handler
     name: ${self:custom.process}
-    environment:
-      CONFIG_TABLE: ${self:custom.config}
-      QUEUE_NAME: ${self:custom.sqs}
-      CONTENT_BUCKET: ${self:custom.contentBucket}
+    environment: ${self:custom.fnEnv}

--- a/test/functions/accept-test.js
+++ b/test/functions/accept-test.js
@@ -1,7 +1,214 @@
+// const { URL } = require("url");
 const { expect } = require("chai");
+const sinon = require("sinon");
+const Hawk = require("hawk");
+const AWS = require("aws-sdk");
 
-describe("functions/accept", () => {
-  it("should work", () => {
-    expect(1).to.equal(1);
+const {
+  DEV_CREDENTIALS,
+  DEFAULT_HAWK_ALGORITHM
+} = require("../../lib/constants");
+
+const mocks = {
+  putObject: (AWS.S3.prototype.putObject = sinon.stub()),
+  getQueueUrl: (AWS.SQS.prototype.getQueueUrl = sinon.stub()),
+  sendMessage: (AWS.SQS.prototype.sendMessage = sinon.stub()),
+  getItem: (AWS.DynamoDB.DocumentClient.prototype.get = sinon.stub())
+};
+
+const accept = require("../../functions/accept");
+
+const mkp = out => ({ promise: () => Promise.resolve(out) });
+
+const CREDENTIALS_TABLE = "test-credentials";
+const QUEUE_NAME = "test-queue";
+const CONTENT_BUCKET = "test-bucket";
+const QueueUrl = "https://example.com/sqs/";
+const ETag = '"abcdef1234567890"';
+const MessageId = "abba123";
+const requestId = "8675309";
+
+describe("functions/accept.post", () => {
+  beforeEach(() => {
+    Object.assign(process.env, {
+      QUEUE_NAME,
+      CONTENT_BUCKET,
+      CREDENTIALS_TABLE
+    });
+    mocks.putObject.returns(mkp({ ETag }));
+    mocks.getQueueUrl.returns(mkp({ QueueUrl }));
+    mocks.sendMessage.returns(mkp({ MessageId }));
+    mocks.getItem.returns(mkp({}));
+    Object.values(mocks).forEach(mock => mock.resetHistory());
+  });
+
+  const acceptPost = async ({
+    httpMethod,
+    proto,
+    host,
+    port,
+    path,
+    id,
+    key,
+    algorithm,
+    body
+  }) => {
+    const hawkResult = Hawk.client.header(
+      `${proto}://${host}:${port}${path}`,
+      httpMethod,
+      { credentials: { id, key, algorithm } }
+    );
+    const headers = {
+      Host: host,
+      "X-Forwarded-Port": port,
+      Authorization: hawkResult.header
+    };
+    return accept.post(
+      { path, httpMethod, headers, body, requestContext: { path, requestId } },
+      {}
+    );
+  };
+
+  describe("Hawk authentication", () => {
+    const expectHawkUnauthorized = result => {
+      expect(result.statusCode).to.equal(401);
+      expect(result.headers["WWW-Authenticate"]).to.equal("Hawk");
+    };
+
+    it("responds with 401 Unauthorized with disabled dev credentials", async () => {
+      process.env.ENABLE_DEV_AUTH = null;
+      process.env.DISABLE_AUTH_CACHE = "1";
+      const id = "devuser";
+      const { key, algorithm } = DEV_CREDENTIALS[id];
+      const result = await acceptPost({
+        httpMethod: "POST",
+        proto: "https",
+        host: "example.com",
+        port: 443,
+        path: "/prod/accept",
+        id,
+        key,
+        algorithm
+      });
+      expectHawkUnauthorized(result);
+    });
+
+    it("responds with 401 Unauthorized with bad id", async () => {
+      process.env.ENABLE_DEV_AUTH = "1";
+      process.env.DISABLE_AUTH_CACHE = "1";
+
+      const badid = "somerando";
+      const key = "realkey";
+
+      mocks.getItem.returns(mkp({}));
+
+      const result = await acceptPost({
+        httpMethod: "POST",
+        proto: "https",
+        host: "example.com",
+        port: 443,
+        path: "/prod/accept",
+        id: badid,
+        key,
+        algorithm: DEFAULT_HAWK_ALGORITHM
+      });
+
+      expect(mocks.getItem.lastCall.args[0]).to.deep.equal({
+        TableName: CREDENTIALS_TABLE,
+        Key: { id: badid },
+        AttributesToGet: ["key", "algorithm"]
+      });
+      expectHawkUnauthorized(result);
+    });
+
+    it("responds with 401 Unauthorized with bad key", async () => {
+      process.env.ENABLE_DEV_AUTH = "1";
+      process.env.DISABLE_AUTH_CACHE = "1";
+
+      const id = "realuser";
+      const key = "realkey";
+      const badkey = "badkey";
+      const algorithm = "sha256";
+
+      mocks.getItem.returns(mkp({ Item: { key, algorithm } }));
+
+      const result = await acceptPost({
+        httpMethod: "POST",
+        proto: "https",
+        host: "example.com",
+        port: 443,
+        path: "/prod/accept",
+        id,
+        key: badkey,
+        algorithm: DEFAULT_HAWK_ALGORITHM
+      });
+
+      expect(mocks.getItem.lastCall.args[0]).to.deep.equal({
+        TableName: CREDENTIALS_TABLE,
+        Key: { id },
+        AttributesToGet: ["key", "algorithm"]
+      });
+      expectHawkUnauthorized(result);
+    });
+
+    it("responds with 200 OK with enabled dev credentials", async () => {
+      process.env.ENABLE_DEV_AUTH = "1";
+      process.env.DISABLE_AUTH_CACHE = "1";
+      const id = "devuser";
+      const { key, algorithm } = DEV_CREDENTIALS[id];
+      const result = await acceptPost({
+        httpMethod: "POST",
+        proto: "https",
+        host: "example.com",
+        port: 443,
+        path: "/prod/accept",
+        id,
+        key,
+        algorithm
+      });
+
+      expect(mocks.putObject.args[0][0]).to.deep.equal({
+        Bucket: CONTENT_BUCKET,
+        Key: requestId,
+        Body: "THIS WILL BE AN IMAGE SOMEDAY"
+      });
+      expect(mocks.getQueueUrl.args[0][0]).to.deep.equal({
+        QueueName: QUEUE_NAME
+      });
+      const message = mocks.sendMessage.args[0][0];
+      const messageBody = JSON.parse(message.MessageBody);
+      expect(messageBody.requestId).to.equal(requestId);
+      expect(message.QueueUrl).to.equal(QueueUrl);
+      expect(result.statusCode).to.equal(200);
+    });
+
+    it("responds with 200 OK with real valid credentials", async () => {
+      process.env.ENABLE_DEV_AUTH = "1";
+      process.env.DISABLE_AUTH_CACHE = "1";
+
+      const id = "realuser";
+      const key = "realkey";
+      const algorithm = "sha256";
+
+      mocks.getItem.returns(mkp({ Item: { key, algorithm } }));
+
+      const result = await acceptPost({
+        httpMethod: "POST",
+        proto: "https",
+        host: "example.com",
+        port: 443,
+        path: "/prod/accept",
+        id,
+        key,
+        algorithm
+      });
+
+      expect(mocks.getItem.lastCall.args[0]).to.deep.equal({
+        TableName: CREDENTIALS_TABLE,
+        Key: { id },
+        AttributesToGet: ["key", "algorithm"]
+      });
+      expect(result.statusCode).to.equal(200);
+    });
   });
 });


### PR DESCRIPTION
- Add prettier, deploy:dev, and client NPM scripts

- bin/client.js as a start on a Hawk-enabled example service client

- Rework accept endpoint function
  - Switch to POST requests
  - Enforce Hawk authentication, with hardcoded dev credential option and
    DynamoDB credentials

- Add Credentials table in DynamoDB

- Tests for Hawk in accept function

- README updates

Fixes #2