### PR TITLE
Update metrics doc.

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,5 +1,5 @@
 # Watchdog Metrics
-*Last Update: 2018-05-18*
+*Last Update: 2018-05-22*
 
 ## Analysis
 Questions we want to answer with metrics data include:
@@ -33,7 +33,7 @@ JSON blobs.  All pings will include the following fields:
 Additional fields submitted are described below.
 
 ### A new item is submitted from a consumer
-- *consumer_id*: the ID of the consumer submitting the request: integer
+- *consumer_name*: the name of the consumer submitting the request: string
 - *event*: "new_item": string
 - *watchdog_id*: the ID assigned to the task: string
 - *type*: Type of item submitted (eg. 'png' or 'jpg'): string
@@ -44,7 +44,7 @@ Example:
   "topic": "watchdog-proxy",
   "timestamp": "2018-05-18T16:38:33.464Z",
 
-  "consumer_id": 101,
+  "consumer_name": "screenshots",
   "event": "new_item",
   "watchdog_id": "9ad08ec4-be1a-4327-b4ef-282bed37621f"
   "type": "png",
@@ -57,6 +57,8 @@ selects a portion of the queue to process and it shuts down when it finishes
 processing them.  When the worker wakes up *or* shuts down, it will send:
 - *event*: "worker_awakes": string
 - *items_in_queue*: Number of items in the queue before the worker removes any: integer
+- *items_in_progress*: Number of items being processed: integer
+- *items_in_waiting*: Number of items waiting to be queued: integer
 - *items_to_claim*: Number of items the worker will take out: integer
 
 Example:
@@ -67,6 +69,8 @@ Example:
 
   "event": "worker_awakes",
   "items_in_queue": 1504,
+  "items_in_progress": 22,
+  "items_in_waiting": 38,
   "items_to_claim": 250
 }
 ```
@@ -74,7 +78,7 @@ Example:
 ### A worker processes the queue
 For *each* item it processes:
 - *event*: "worker_works": string
-- *consumer_id*: the ID of the consumer submitting the request: integer
+- *consumer_name*: the ID of the consumer submitting the request: string
 - *watchdog_id*: the ID assigned to the task: string
 - *photodna_tracking_id*: ID from PhotoDNA: string
 - *is_match*: Whether the response was positive or negative: boolean
@@ -91,7 +95,7 @@ Example:
   "timestamp": "2018-05-18T16:38:33.464Z",
 
   "event": "worker_works",
-  "consumer_id": 101,
+  "consumer_name": "screenshots,
   "watchdog_id": "9ad08ec4-be1a-4327-b4ef-282bed37621f"
   "photodna_tracking_id": "1_photodna_a0e3d02b-1a0a-4b38-827f-764acd288c25",
   "is_match": false,
@@ -108,7 +112,6 @@ Example:
 When a worker finishes the work it claimed it shuts down.  When it does, it will
 send:
 - *event*: "worker_sleeps": string
-- *items_in_queue*: Number of items in the queue: integer
 - *items_processed*: Number of items the worker processed successfully: integer
 
 Example:
@@ -118,7 +121,6 @@ Example:
   "timestamp": "2018-05-18T16:38:33.464Z",
 
   "event": "worker_sleeps",
-  "items_in_queue": 1504,
   "items_processed": 250
 }
 ```


### PR DESCRIPTION
- Replace "consumer_id" with "consumer_name".
- Remove "items_in_queue" from the "worker_sleeps" event.
- Add "items_in_progress" and "items_in_waiting" to "worker_awakes".

Fixes #58.  Updates #47.