### PR TITLE
Fix the queue attributes used in heartbeat ping

### DIFF
--- a/functions/pollQueue.js
+++ b/functions/pollQueue.js
@@ -122,11 +122,7 @@ const sendHeartbeatMetrics = async (
   const { QueueUrl } = await SQS.getQueueUrl({
     QueueName: QUEUE_NAME
   }).promise();
-  const {
-    ApproximateNumberOfMessages: items_in_queue,
-    ApproximateNumberOfMessagesDelayed: items_in_waiting,
-    ApproximateNumberOfMessagesNotVisible: items_in_progress
-  } = await SQS.getQueueAttributes({
+  const attribsResult = await SQS.getQueueAttributes({
     QueueUrl,
     AttributeNames: [
       "ApproximateNumberOfMessages",
@@ -134,6 +130,12 @@ const sendHeartbeatMetrics = async (
       "ApproximateNumberOfMessagesNotVisible"
     ]
   }).promise();
+  const {
+    ApproximateNumberOfMessages: items_in_queue,
+    ApproximateNumberOfMessagesDelayed: items_in_waiting,
+    ApproximateNumberOfMessagesNotVisible: items_in_progress
+  } =
+    attribsResult.Attributes || {};
   await Metrics.pollerHeartbeat({
     poller_id,
     items_in_queue,

--- a/lib/test-setup.js
+++ b/lib/test-setup.js
@@ -79,7 +79,9 @@ global.resetMocks = () => {
   mocks.deleteItem.returns(makePromiseFn({}));
   mocks.putItem.returns(makePromiseFn({}));
   mocks.getItem.returns(makePromiseFn({}));
-  mocks.getQueueAttributes.returns(makePromiseFn({ QueueAttributes }));
+  mocks.getQueueAttributes.returns(
+    makePromiseFn({ Attributes: QueueAttributes })
+  );
   mocks.getQueueUrl.returns(makePromiseFn({ QueueUrl }));
   mocks.getSignedUrl.returns("");
   mocks.putObject.returns(makePromiseFn({ ETag }));


### PR DESCRIPTION
Turns out that the attributes weren't at the root of the response object for the getQueueAttributes call.