### PR TITLE
Reduce queue retries from 10 to 3

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -141,7 +141,7 @@ resources:
             Fn::GetAtt:
             - MessagesDeadLetterQueue
             - Arn
-          maxReceiveCount: 10
+          maxReceiveCount: 3
 
     MessagesDeadLetterQueue:
       Type: AWS::SQS::Queue


### PR DESCRIPTION
- 10 is probably too many times for a non-recoverable error - e.g. permanently
  unreachable consuming client

- 3 is probably enough for an intermittent problem - e.g. temporary service
  outage