### PR TITLE
Switch to epoch in milliseconds for metric timestamp

### DIFF
--- a/lib/metrics-test.js
+++ b/lib/metrics-test.js
@@ -39,6 +39,9 @@ describe("lib/metrics", () => {
       await subject(Object.assign({ ignored: "extra" }, params));
       const body = mocks.requestPost.args[0][0].body;
       expect(body).to.include.key("timestamp");
+      // Hacky test to assert that the timestamp is roughly equivalent to the
+      // current time in milliseconds - e.g. not an ISO8601 string or other
+      expect(Date.now() - parseInt(body.timestamp) < 1000).to.be.true;
       delete body.timestamp;
       expect(body).to.deep.equal(
         Object.assign(

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -23,7 +23,7 @@ const Metrics = (module.exports = {
       body: Object.assign(
         {
           topic: "watchdog-proxy",
-          timestamp: new Date().toISOString()
+          timestamp: Date.now()
         },
         data
       )


### PR DESCRIPTION
Fixes #147