### PR TITLE
Re-enable comma dangle eslint rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -15,7 +15,6 @@ root: true
 rules:
   node/no-unpublished-require: off
   no-console: off
-  comma-dangle: off
 
 overrides:
   -

--- a/bin/client.js
+++ b/bin/client.js
@@ -43,14 +43,14 @@ async function main() {
     credentials: {
       id: program.id || "devuser",
       key: program.key || "devkey",
-      algorithm: "sha256"
-    }
+      algorithm: "sha256",
+    },
   });
 
   const formData = {
     image: program.image ? fs.createReadStream(program.image) : DEFAULT_IMAGE,
     negative_uri,
-    positive_uri
+    positive_uri,
   };
   if (program.email) {
     formData.positive_email = program.email;
@@ -63,7 +63,7 @@ async function main() {
     method: "POST",
     url,
     headers: { Authorization },
-    formData
+    formData,
   });
 }
 

--- a/config/dynamic.js
+++ b/config/dynamic.js
@@ -13,6 +13,6 @@ module.exports = async () => {
   }
 
   return {
-    GIT_COMMIT
+    GIT_COMMIT,
   };
 };

--- a/functions/accept-test.js
+++ b/functions/accept-test.js
@@ -8,7 +8,7 @@ const {
   mocks,
   makePromiseFn,
   env: { UPSTREAM_SERVICE_URL, CREDENTIALS_TABLE, QUEUE_NAME, CONTENT_BUCKET },
-  constants: { QueueUrl, requestId }
+  constants: { QueueUrl, requestId },
 } = global;
 
 const Metrics = require("../lib/metrics");
@@ -47,7 +47,7 @@ describe("functions/accept.post", () => {
         path: "/prod/accept",
         id,
         key,
-        algorithm
+        algorithm,
       });
       expectHawkUnauthorized(result);
     });
@@ -66,13 +66,13 @@ describe("functions/accept.post", () => {
         path: "/prod/accept",
         id: badid,
         key,
-        algorithm: DEFAULT_HAWK_ALGORITHM
+        algorithm: DEFAULT_HAWK_ALGORITHM,
       });
 
       expect(mocks.getItem.lastCall.args[0]).to.deep.equal({
         TableName: CREDENTIALS_TABLE,
         Key: { id: badid },
-        AttributesToGet: ["key", "algorithm"]
+        AttributesToGet: ["key", "algorithm"],
       });
       expectHawkUnauthorized(result);
     });
@@ -93,13 +93,13 @@ describe("functions/accept.post", () => {
         path: "/prod/accept",
         id,
         key: badkey,
-        algorithm: DEFAULT_HAWK_ALGORITHM
+        algorithm: DEFAULT_HAWK_ALGORITHM,
       });
 
       expect(mocks.getItem.lastCall.args[0]).to.deep.equal({
         TableName: CREDENTIALS_TABLE,
         Key: { id },
-        AttributesToGet: ["key", "algorithm"]
+        AttributesToGet: ["key", "algorithm"],
       });
       expectHawkUnauthorized(result);
     });
@@ -116,7 +116,7 @@ describe("functions/accept.post", () => {
         path: "/prod/accept",
         id,
         key,
-        algorithm
+        algorithm,
       });
 
       // Dev credentials don't hit the database
@@ -139,13 +139,13 @@ describe("functions/accept.post", () => {
         path: "/prod/accept",
         id,
         key,
-        algorithm
+        algorithm,
       });
 
       expect(mocks.getItem.lastCall.args[0]).to.deep.equal({
         TableName: CREDENTIALS_TABLE,
         Key: { id },
-        AttributesToGet: ["key", "algorithm"]
+        AttributesToGet: ["key", "algorithm"],
       });
       expect(result.statusCode).to.equal(201);
     });
@@ -169,7 +169,7 @@ describe("functions/accept.post", () => {
         id,
         key,
         algorithm,
-        body
+        body,
       });
 
       expect(result.statusCode).to.equal(400);
@@ -187,8 +187,8 @@ describe("functions/accept.post", () => {
         image: {
           filename: "image.jpg",
           contentType: imageContentType,
-          content: imageContent
-        }
+          content: imageContent,
+        },
       });
 
       const result = await acceptPost({
@@ -200,7 +200,7 @@ describe("functions/accept.post", () => {
         id,
         key,
         algorithm,
-        body
+        body,
       });
 
       const imageKey = `image-${requestId}`;
@@ -209,10 +209,10 @@ describe("functions/accept.post", () => {
         Bucket: CONTENT_BUCKET,
         Key: imageKey,
         Body: Buffer.from(imageContent),
-        ContentType: imageContentType
+        ContentType: imageContentType,
       });
       expect(mocks.getQueueUrl.args[0][0]).to.deep.equal({
-        QueueName: QUEUE_NAME
+        QueueName: QUEUE_NAME,
       });
 
       const message = mocks.sendMessage.args[0][0];
@@ -232,14 +232,14 @@ describe("functions/accept.post", () => {
         Bucket: CONTENT_BUCKET,
         Key: `${imageKey}-request.json`,
         Body: message.MessageBody,
-        ContentType: "application/json"
+        ContentType: "application/json",
       });
 
       expect(metricsStub.called).to.be.true;
       expect(metricsStub.args[0][0]).to.deep.include({
         consumer_name: id,
         watchdog_id: requestId,
-        type: imageContentType
+        type: imageContentType,
       });
 
       expect(result.statusCode).to.equal(201);
@@ -255,8 +255,8 @@ const DEFAULT_POST_BODY = {
   image: {
     filename: "image.jpg",
     contentType: "image/jpeg",
-    content: "1234123412341234"
-  }
+    content: "1234123412341234",
+  },
 };
 
 async function acceptPost({
@@ -268,7 +268,7 @@ async function acceptPost({
   id,
   key,
   algorithm,
-  body = DEFAULT_POST_BODY
+  body = DEFAULT_POST_BODY,
 }) {
   const { contentType, encodedBody } = buildBody(body);
   const hawkResult = Hawk.client.header(
@@ -280,7 +280,7 @@ async function acceptPost({
     Host: host,
     "X-Forwarded-Port": port,
     "Content-Type": contentType,
-    Authorization: hawkResult.header
+    Authorization: hawkResult.header,
   };
   return accept.post(
     {
@@ -288,7 +288,7 @@ async function acceptPost({
       httpMethod,
       headers,
       body: encodedBody,
-      requestContext: { path, requestId }
+      requestContext: { path, requestId },
     },
     {}
   );
@@ -321,7 +321,7 @@ function buildBody(data) {
             : encFile(name, value)
       )
       .join("--" + boundary + "\r\n"),
-    `--${boundary}--`
+    `--${boundary}--`,
   ].join("");
 
   return { contentType, encodedBody };

--- a/functions/heartbeat-test.js
+++ b/functions/heartbeat-test.js
@@ -7,7 +7,7 @@ describe("functions/heartbeat.handler", () => {
   it("responds with 200 OK", async () => {
     const result = await heartbeat.handler({
       path: "/dev/__heartbeat__",
-      httpMethod: "GET"
+      httpMethod: "GET",
     });
     expect(result.statusCode).to.equal(200);
     expect(JSON.parse(result.body)).to.deep.equal({ status: "OK" });

--- a/functions/heartbeat.js
+++ b/functions/heartbeat.js
@@ -4,6 +4,6 @@ module.exports.handler = async function(event, context) {
   return {
     statusCode: 200,
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ status: "OK" })
+    body: JSON.stringify({ status: "OK" }),
   };
 };

--- a/functions/mockEndpoints.js
+++ b/functions/mockEndpoints.js
@@ -33,7 +33,7 @@ function response(statusCode, body, headers = {}) {
   return {
     statusCode,
     headers: Object.assign({ "Content-Type": "application/json" }, headers),
-    body: JSON.stringify(body)
+    body: JSON.stringify(body),
   };
 }
 
@@ -41,16 +41,16 @@ const baseMatchResponse = {
   Status: {
     Code: 3000,
     Description: "OK",
-    Exception: null
+    Exception: null,
   },
   ContentId: null,
   IsMatch: false,
   MatchDetails: {
     AdvancedInfo: [],
-    MatchFlags: []
+    MatchFlags: [],
   },
   XPartnerCustomerId: null,
   TrackingId:
     "WUS_418b5903425346a1b1451821c5cd06ee_57c7457ae3a97812ecf8bde9_ddba296dab39454aa00cf0b17e0eb7bf",
-  EvaluateResponse: null
+  EvaluateResponse: null,
 };

--- a/functions/periodicMetrics-test.js
+++ b/functions/periodicMetrics-test.js
@@ -18,7 +18,7 @@ describe("functions/periodicMetrics.handler", () => {
     const getRemainingTimeInMillis = sinon.stub().returns(100);
     const context = {
       awsRequestId: "foo",
-      getRemainingTimeInMillis
+      getRemainingTimeInMillis,
     };
 
     await subject(event, context);
@@ -37,7 +37,7 @@ describe("functions/periodicMetrics.handler", () => {
       .returns(90);
     const context = {
       awsRequestId: "foo",
-      getRemainingTimeInMillis
+      getRemainingTimeInMillis,
     };
 
     await subject(event, context);
@@ -51,7 +51,7 @@ describe("functions/periodicMetrics.handler", () => {
     const {
       ApproximateNumberOfMessages,
       ApproximateNumberOfMessagesDelayed,
-      ApproximateNumberOfMessagesNotVisible
+      ApproximateNumberOfMessagesNotVisible,
     } = constants.QueueAttributes;
 
     expect(postCalls[0][0].body).to.deep.include({
@@ -59,7 +59,7 @@ describe("functions/periodicMetrics.handler", () => {
       poller_id: context.awsRequestId,
       items_in_queue: ApproximateNumberOfMessages,
       items_in_waiting: ApproximateNumberOfMessagesDelayed,
-      items_in_progress: ApproximateNumberOfMessagesNotVisible
+      items_in_progress: ApproximateNumberOfMessagesNotVisible,
     });
   });
 });

--- a/functions/periodicMetrics.js
+++ b/functions/periodicMetrics.js
@@ -40,15 +40,15 @@ const sendHeartbeatMetrics = async (
 ) => {
   const apiStartTime = Date.now();
   const { QueueUrl } = await SQS.getQueueUrl({
-    QueueName: QUEUE_NAME
+    QueueName: QUEUE_NAME,
   }).promise();
   const attribsResult = await SQS.getQueueAttributes({
     QueueUrl,
     AttributeNames: [
       "ApproximateNumberOfMessages",
       "ApproximateNumberOfMessagesDelayed",
-      "ApproximateNumberOfMessagesNotVisible"
-    ]
+      "ApproximateNumberOfMessagesNotVisible",
+    ],
   }).promise();
   const apiEndTime = Date.now();
   logDebug("SQS.getQueueAttributes duration", apiEndTime - apiStartTime, "ms");
@@ -56,15 +56,14 @@ const sendHeartbeatMetrics = async (
   const {
     ApproximateNumberOfMessages: items_in_queue,
     ApproximateNumberOfMessagesDelayed: items_in_waiting,
-    ApproximateNumberOfMessagesNotVisible: items_in_progress
-  } =
-    attribsResult.Attributes || {};
+    ApproximateNumberOfMessagesNotVisible: items_in_progress,
+  } = attribsResult.Attributes || {};
 
   const pingData = {
     poller_id,
     items_in_queue,
     items_in_progress,
-    items_in_waiting
+    items_in_waiting,
   };
   logDebug("pingData", jsonPretty(pingData));
   return Metrics.pollerHeartbeat(pingData);

--- a/functions/processQueueItem-test.js
+++ b/functions/processQueueItem-test.js
@@ -5,7 +5,7 @@ const {
   makePromiseFn,
   mocks,
   env: { CONTENT_BUCKET, UPSTREAM_SERVICE_URL, UPSTREAM_SERVICE_KEY },
-  constants: { ReceiptHandle }
+  constants: { ReceiptHandle },
 } = global;
 
 const awsRequestId = "test-uuid";
@@ -38,11 +38,11 @@ describe("functions/processQueueItem.handler", () => {
     const deleteCalls = mocks.deleteObject.args;
     expect(deleteCalls[0][0]).to.deep.equal({
       Bucket: CONTENT_BUCKET,
-      Key: `${defaultMessage.image}`
+      Key: `${defaultMessage.image}`,
     });
     expect(deleteCalls[1][0]).to.deep.equal({
       Bucket: CONTENT_BUCKET,
-      Key: `${defaultMessage.image}-request.json`
+      Key: `${defaultMessage.image}-request.json`,
     });
   });
 
@@ -54,7 +54,7 @@ describe("functions/processQueueItem.handler", () => {
       positive_uri,
       positive_email,
       notes,
-      image
+      image,
     } = defaultMessage;
 
     mocks.requestPost
@@ -69,8 +69,8 @@ describe("functions/processQueueItem.handler", () => {
     expect(sendEmailCall).to.deep.include({
       Source: global.env.EMAIL_FROM,
       Destination: {
-        ToAddresses: [defaultMessage.positive_email]
-      }
+        ToAddresses: [defaultMessage.positive_email],
+      },
     });
     [id, user].forEach(v =>
       expect(sendEmailCall.Message.Subject.Data).to.include(v)
@@ -91,7 +91,7 @@ describe("functions/processQueueItem.handler", () => {
       positive_email,
       notes,
       image,
-      response: positiveMatchResponse
+      response: positiveMatchResponse,
     });
   });
 
@@ -147,35 +147,35 @@ describe("functions/processQueueItem.handler", () => {
       {
         Bucket: CONTENT_BUCKET,
         Expires: 600,
-        Key: defaultMessage.image
-      }
+        Key: defaultMessage.image,
+      },
     ]);
 
     expect(mocks.requestPost.args[0][0]).to.deep.equal({
       url: `${UPSTREAM_SERVICE_URL}?enhance`,
       headers: {
         "Content-Type": "application/json",
-        "Ocp-Apim-Subscription-Key": UPSTREAM_SERVICE_KEY
+        "Ocp-Apim-Subscription-Key": UPSTREAM_SERVICE_KEY,
       },
       json: true,
       body: {
         DataRepresentation: "URL",
-        Value: signedImageUrl
-      }
+        Value: signedImageUrl,
+      },
     });
 
     expect(mocks.requestPost.args[1][0]).to.deep.equal({
       url: defaultMessage[positive ? "positive_uri" : "negative_uri"],
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
       },
       json: true,
       body: {
         watchdog_id: defaultMessage.id,
         notes: defaultMessage.notes,
         response: positive ? positiveMatchResponse : negativeMatchResponse,
-        positive
-      }
+        positive,
+      },
     });
 
     const response = positive ? positiveMatchResponse : negativeMatchResponse;
@@ -186,7 +186,7 @@ describe("functions/processQueueItem.handler", () => {
       watchdog_id: defaultMessage.id,
       photodna_tracking_id: response.TrackingId,
       is_error: false,
-      is_match: response.IsMatch
+      is_match: response.IsMatch,
     });
     expect(metricsStub.args[0][0]).to.include.keys(
       "timing_sent",
@@ -200,25 +200,25 @@ const negativeMatchResponse = {
   Status: {
     Code: 3000,
     Description: "OK",
-    Exception: null
+    Exception: null,
   },
   ContentId: null,
   IsMatch: false,
   MatchDetails: {
     AdvancedInfo: [],
-    MatchFlags: []
+    MatchFlags: [],
   },
   XPartnerCustomerId: null,
   TrackingId:
     "WUS_418b5903425346a1b1451821c5cd06ee_57c7457ae3a97812ecf8bde9_ddba296dab39454aa00cf0b17e0eb7bf",
-  EvaluateResponse: null
+  EvaluateResponse: null,
 };
 
 const positiveMatchResponse = {
   Status: {
     Code: 3000,
     Description: "OK",
-    Exception: null
+    Exception: null,
   },
   ContentId: null,
   IsMatch: true,
@@ -229,18 +229,18 @@ const positiveMatchResponse = {
         AdvancedInfo: [
           {
             Key: "MatchId",
-            Value: "117721"
-          }
+            Value: "117721",
+          },
         ],
         Source: "Test",
-        Violations: ["A1"]
-      }
-    ]
+        Violations: ["A1"],
+      },
+    ],
   },
   XPartnerCustomerId: null,
   TrackingId:
     "WUS_418b5903425346a1b1451821c5cd06ee_57c7457ae3a97812ecf8bde9_0709e0136ee342e993092edceecbc407",
-  EvaluateResponse: null
+  EvaluateResponse: null,
 };
 
 const defaultMessage = {
@@ -252,7 +252,7 @@ const defaultMessage = {
   positive_uri: "https://example.com/positive?id=123",
   positive_email: "foo@example.com",
   notes: "this is a test",
-  image: "image-8675309"
+  image: "image-8675309",
 };
 
 const makeBody = (message = {}) =>

--- a/functions/version-test.js
+++ b/functions/version-test.js
@@ -10,13 +10,13 @@ describe("functions/version.handler", () => {
     process.env.GIT_COMMIT = GIT_COMMIT;
     const result = await version.handler({
       path: "/dev/__version__",
-      httpMethod: "GET"
+      httpMethod: "GET",
     });
     expect(result.statusCode).to.equal(200);
     expect(JSON.parse(result.body)).to.deep.equal({
       commit: GIT_COMMIT,
       version: packageMeta.version,
-      source: packageMeta.repository.url
+      source: packageMeta.repository.url,
     });
   });
 });

--- a/functions/version.js
+++ b/functions/version.js
@@ -9,7 +9,7 @@ module.exports.handler = async function(event, context) {
     body: JSON.stringify({
       commit,
       version: packageMeta.version,
-      source: packageMeta.repository.url
-    })
+      source: packageMeta.repository.url,
+    }),
   };
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,8 +3,8 @@ module.exports = {
   DEV_CREDENTIALS: {
     devuser: {
       key: "devkey",
-      algorithm: "sha256"
-    }
+      algorithm: "sha256",
+    },
   },
   RATE_LIMIT: 5,
   RATE_PERIOD: 1000,
@@ -13,5 +13,5 @@ module.exports = {
   POLL_DELAY: 100,
   DEFAULT_METRICS_PING_PERIOD: 1000,
   TILES_STAGE_URL: "https://onyx_tiles.stage.mozaws.net/v3/links/ping-centre",
-  TILES_PROD_URL: "https://tiles.services.mozilla.com/v3/links/ping-centre"
+  TILES_PROD_URL: "https://tiles.services.mozilla.com/v3/links/ping-centre",
 };

--- a/lib/metrics-test.js
+++ b/lib/metrics-test.js
@@ -47,7 +47,7 @@ describe("lib/metrics", () => {
         Object.assign(
           {
             topic: "watchdog-proxy",
-            event
+            event,
           },
           params
         )
@@ -60,7 +60,7 @@ describe("lib/metrics", () => {
         await expectPostBody(subject, "new_item", {
           consumer_name: "foo",
           watchdog_id: "bar",
-          type: "baz"
+          type: "baz",
         });
       });
     });
@@ -72,7 +72,7 @@ describe("lib/metrics", () => {
           poller_id: "123",
           items_in_queue: "456",
           items_in_progress: "789",
-          items_in_waiting: "012"
+          items_in_waiting: "012",
         });
       });
     });
@@ -90,7 +90,7 @@ describe("lib/metrics", () => {
           timing_retrieved: "jkl",
           timing_sent: "zxc",
           timing_received: "vbn",
-          timing_submitted: "mnb"
+          timing_submitted: "mnb",
         });
       });
     });

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -23,10 +23,10 @@ const Metrics = (module.exports = {
       body: Object.assign(
         {
           topic: "watchdog-proxy",
-          timestamp: Date.now()
+          timestamp: Date.now(),
         },
         data
-      )
+      ),
     });
   },
 
@@ -35,21 +35,21 @@ const Metrics = (module.exports = {
       event: "new_item",
       consumer_name,
       watchdog_id,
-      type
+      type,
     }),
 
   pollerHeartbeat: ({
     poller_id,
     items_in_queue,
     items_in_progress,
-    items_in_waiting
+    items_in_waiting,
   }) =>
     Metrics.ping({
       event: "poller_heartbeat",
       poller_id,
       items_in_queue,
       items_in_progress,
-      items_in_waiting
+      items_in_waiting,
     }),
 
   workerWorks: ({
@@ -62,7 +62,7 @@ const Metrics = (module.exports = {
     timing_retrieved,
     timing_sent,
     timing_received,
-    timing_submitted
+    timing_submitted,
   }) =>
     Metrics.ping({
       event: "worker_works",
@@ -75,6 +75,6 @@ const Metrics = (module.exports = {
       timing_retrieved,
       timing_sent,
       timing_received,
-      timing_submitted
-    })
+      timing_submitted,
+    }),
 });

--- a/lib/test-setup.js
+++ b/lib/test-setup.js
@@ -16,7 +16,7 @@ global.env = {
   EMAIL_TO: "",
   EMAIL_EXPIRES: 600,
   LOG_DEBUG: "0",
-  LOG_INFO: "0"
+  LOG_INFO: "0",
 };
 
 global.constants = {
@@ -25,7 +25,7 @@ global.constants = {
   QueueAttributes: {
     ApproximateNumberOfMessages: 200,
     ApproximateNumberOfMessagesDelayed: 20,
-    ApproximateNumberOfMessagesNotVisible: 2
+    ApproximateNumberOfMessagesNotVisible: 2,
   },
   MessageId: "abba123",
   requestId: "8675309",
@@ -39,15 +39,15 @@ global.constants = {
     ETag: '"ae1e7accaab42504a930ecc6e6aa34c2"',
     ContentType: "image/jpeg",
     Metadata: {},
-    Body: Buffer.from("THIS IS NOT AN IMAGE")
-  }
+    Body: Buffer.from("THIS IS NOT AN IMAGE"),
+  },
 };
 
 const defaultConstantsModule = Object.assign({}, require("./constants"), {
   RATE_PERIOD: 500,
   RATE_LIMIT: 2,
   RATE_WAIT: 10,
-  MIN_HEARTBEAT_PERIOD: 0
+  MIN_HEARTBEAT_PERIOD: 0,
 });
 global.constantsModule = Object.assign({}, defaultConstantsModule);
 mockRequire("./constants", global.constantsModule);
@@ -60,7 +60,7 @@ global.resetMocks = () => {
   const {
     mocks,
     makePromiseStub,
-    constants: { QueueUrl, QueueAttributes, MessageId, ETag }
+    constants: { QueueUrl, QueueAttributes, MessageId, ETag },
   } = global;
 
   Object.assign(global.constantsModule, defaultConstantsModule);
@@ -82,7 +82,7 @@ global.resetMocks = () => {
     putItem: (pDocumentClient.put = makePromiseStub({})),
     deleteItem: (pDocumentClient.delete = makePromiseStub({})),
     getQueueAttributes: (pSQS.getQueueAttributes = makePromiseStub({
-      Attributes: QueueAttributes
+      Attributes: QueueAttributes,
     })),
     getQueueUrl: (pSQS.getQueueUrl = makePromiseStub({ QueueUrl })),
     getSignedUrl: (pS3.getSignedUrl = sinon.stub().returns("")),
@@ -91,7 +91,7 @@ global.resetMocks = () => {
     requestPost: (request.post = sinon.stub().resolves({})),
     sendMessage: (pSQS.sendMessage = makePromiseStub({ MessageId })),
     receiveMessage: (pSQS.receiveMessage = makePromiseStub({ MessageId })),
-    invoke: (pLambda.invoke = makePromiseStub({}))
+    invoke: (pLambda.invoke = makePromiseStub({})),
   });
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,5 +32,5 @@ module.exports = {
   jsonPretty,
   md5,
   wait,
-  epochNow
+  epochNow,
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "info": "serverless info",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint .",
-    "prettier": "prettier --write \"{functions,lib,bin}/**/*.js\"",
+    "prettier": "prettier --trailing-comma=es5 --write \"{functions,lib,bin}/**/*.js\"",
     "logs": "serverless logs",
     "postlint": "nsp check -o summary",
     "nsp": "nsp check",


### PR DESCRIPTION
Upgrading the Mozilla eslint plugin brought in a new `comma-dangle` rule. I disabled it along with the upgrade because a) I don't like it and b) it fought with the auto-formatting done by prettier.

Well, I still don't like the rule, but I figured out how to make prettier work with it. So, if it's recommended Mozilla style, I guess we can roll with it and I'll deal.