### PR TITLE
Update Renovate Configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "group:all"
   ],
+  "patch" : { "enabled": false },
   "schedule": ["before 5am on monday"]
 }


### PR DESCRIPTION
This might be a mistake, but I want to try tweaking Renovate to ignore patch version upgrades and lump everything into one PR. Been keeping up with the individual upgrades alright, but it has been a chore. Maybe this will reduce the task a little bit